### PR TITLE
rename yii\base\Object to yii\base\BaseObject

### DIFF
--- a/components/API.php
+++ b/components/API.php
@@ -7,7 +7,10 @@ use Yii;
  * Base API component. Used by all modules
  * @package yii\easyii\components
  */
-class API extends \yii\base\Object
+if(!class_exists('yii\base\BaseObject'))
+    class_alias('yii\base\Object', 'yii\base\BaseObject');
+
+class API extends \yii\base\BaseObject
 {
     /** @var  array */
     static $classes;

--- a/components/ApiObject.php
+++ b/components/ApiObject.php
@@ -8,7 +8,10 @@ use yii\easyii\helpers\Image;
  * Class ApiObject
  * @package yii\easyii\components
  */
-class ApiObject extends \yii\base\Object
+if(!class_exists('yii\base\BaseObject'))
+    class_alias('yii\base\Object', 'yii\base\BaseObject');
+
+class ApiObject extends \yii\base\BaseObject
 {
     /** @var \yii\base\Model  */
     public $model;


### PR DESCRIPTION
fix for error using package with php 7.2 "Cannot use 'Object' as class name as it is reserved"